### PR TITLE
Update SpeedUp Logic

### DIFF
--- a/Package/DialogueSystem/Scripts/View/DialogueView.cs
+++ b/Package/DialogueSystem/Scripts/View/DialogueView.cs
@@ -49,7 +49,8 @@ namespace ProjectBSR.DialogueSystem.View
         
         public static event System.Action<SpeedState> OnSpeedStateChanged;
         private SpeedState currentSpeedState = SpeedState.Normal;
-        public float TimeMultiplier => currentSpeedState == SpeedState.Accelerated ? 0.5f : 1f;
+        public float TimeMultiplier => currentSpeedState == SpeedState.Accelerated ? 0f : 1f;
+        private float acceleratedCooldown = 0.2f;
         
         private void OnDisable()
         {
@@ -122,7 +123,7 @@ namespace ProjectBSR.DialogueSystem.View
             typeEffect.ShowText(text);
             if (currentSpeedState == SpeedState.Accelerated)
             {
-                typeEffect.SetTypewriterSpeed(2f);
+                typeEffect.SkipTypewriter();
             }
         }
 
@@ -131,12 +132,18 @@ namespace ProjectBSR.DialogueSystem.View
             if (currentSpeedState == SpeedState.Accelerated)
             {
                 state = State.None;
-                OnDialogueTextCompleted?.Invoke();
+                InvokeDialogueTextCompletedWithCooldown();
             }
             else
             {
                 state = State.TypeCompleted;
             }
+        }
+        
+        private async void InvokeDialogueTextCompletedWithCooldown()
+        {
+            await UniTask.Delay(System.TimeSpan.FromSeconds(acceleratedCooldown));
+            OnDialogueTextCompleted?.Invoke();
         }
 
         private void Update()
@@ -182,7 +189,7 @@ namespace ProjectBSR.DialogueSystem.View
                 else if (state == State.TypeCompleted)
                 {
                     state = State.None;
-                    OnDialogueTextCompleted?.Invoke();
+                    InvokeDialogueTextCompletedWithCooldown();
                 }
             }
 
@@ -209,7 +216,7 @@ namespace ProjectBSR.DialogueSystem.View
                 return;
             }
 
-            if (fadeTime <= 0)
+            if (fadeTime < 0)
             {
                 Debug.LogError("BlackIn fadeTime must be greater than 0. Setting to 0.");
                 fadeTime = 0;
@@ -255,7 +262,7 @@ namespace ProjectBSR.DialogueSystem.View
                 return;
             }
 
-            if (fadeTime <= 0)
+            if (fadeTime < 0)
             {
                 Debug.LogError("BlackOut fadeTime must be greater than 0. Setting to 0.");
                 fadeTime = 0;


### PR DESCRIPTION
## 主要改動簡述

重新設計劇情加速模式（LeftCtrl）的行為邏輯：原本加速只是把動畫速度乘以 0.5x，改為所有指令在加速期間立刻完成，並在每個 Say 指令打完字後強制等待一段冷卻時間，避免玩家完全看不到劇情。

## 改動內容

1. "TimeMultiplier" 的加速時間從 "0.5f" 改為 "0f"，所有帶有時間的動畫（如BlackIn/Out、角色動畫、CG等）都會立刻完成。
2. "PlayTypeEffect" 在加速狀態時改成呼叫 "SkipTypewriter()" 來直接跳過打字。
3. "TextAnimator_OnTypingCompleted" ＆ "SetSpeedState" 處於加速自動推進時，改成等待 "acceleratedCooldown" 秒後再觸發下一行。
4. 新增 "float acceleratedCooldown"（預設為 0.2 秒），目前沒有序列化在Inspector，而是直接寫死數字。
5. 修正 "BlackIn" ＆ "BlackOut" 的 "fadeTime <= 0" 誤報 Error（這邊讓 0 變成合法值）。

## 測試方法

1. 正常模式下點擊推進劇情，行為與修改前相同，會根據Data設定正常推進。
2. 按住 LeftCtrl，BlackIn/BlackOut 會立刻完成，Say 文字也會立刻顯示完畢，接著會等帶指定秒數過了以後才自動跳下一行。
4. 打字途中按下 LeftCtrl，文字也會立刻補完，再等指定秒數後繼續。
5. 直接調整 Accelerated Cooldown 數值，可以讓等待時間產生變化。